### PR TITLE
Add argument to dataImport function to allow for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,13 @@
 Awesome App Dev Elite Mega Pro Hackers
 
 ## Contents
-  * [Installation](#installation)
-  * [Testing](#testing)
-     * [Test Scripts](#test-scripts)
-     * [Running Tests](#running-tests)
-     * [CI Tests](#ci-tests)
-  * [Loading Data](#loading-data)
+
+- [Installation](#installation)
+- [Testing](#testing)
+  - [Test Scripts](#test-scripts)
+  - [Running Tests](#running-tests)
+  - [CI Tests](#ci-tests)
+- [Loading Data](#loading-data)
 
 ## Installation
 
@@ -21,9 +22,11 @@ After luarocks is installed open a terminal and run the command `luarocks instal
 ## Testing
 
 ### Test Scripts
+
 All of the unit tests in this project live in the `./corona-app/spec/` directory and must have a name ending in `_spec.lua` (e.g. `data-import_spec.lua`).
 
 ### Running Tests
+
 To run the tests, first make sure that you have the busted library installed, [instructions here](#Installation), then:
 
 ```
@@ -41,9 +44,11 @@ This project uses the [Travis CI](https://travis-ci.org/) service to automatical
 
 To load country data in the application use the following code.
 
+**In a unit test**
+
 ```lua
 local dataImport = require("data-import")
-local countries = dataImport()
+local countries = dataImport("data/country.json")
 
 --[[
   Countries is a table of country tables, each contains the following
@@ -51,6 +56,15 @@ local countries = dataImport()
       country.score (eg 34)
       country.flag (eg 'Afghanistan-01.png')
 ]]--
+```
+
+**In Corona**
+
+```lua
+local dataImport = require("data-import")
+local countries = dataImport(system.pathForFile("data/country.json"))
+
+-- Same data as above example
 ```
 
 ### Printing Tables

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # awesome-app-dev
 
+[![Build Status](https://travis-ci.org/cahilfoley/awesome-app-dev.svg?branch=develop)](https://travis-ci.org/cahilfoley/awesome-app-dev)
+
 Awesome App Dev Elite Mega Pro Hackers
 
 ## Contents

--- a/corona-app/data-import.lua
+++ b/corona-app/data-import.lua
@@ -1,6 +1,4 @@
 local json = require("vendor.dkjson")
-local printTable = require('utils.print-table')
-local pathForFile = system.pathForFile("data/country.json")
 
 local excludes = {
   'Belize',
@@ -32,7 +30,7 @@ function isExcluded(name)
   return false
 end
 
-function dataImport()
+function dataImport(pathForFile)
   -- Read the JSON file as a string
   local fileData = io.open(pathForFile, 'rb')
   local jsonString = fileData:read('*all')

--- a/corona-app/main.lua
+++ b/corona-app/main.lua
@@ -13,7 +13,8 @@ local composer = require "composer"
 
 -- read the country data
 local dataImport = require "data-import"
-local countries = dataImport()
+local pathForFile = system.pathForFile "data/country.json"
+local countries = dataImport(pathForFile)
 
 -- event listeners for tab buttons:
 local function onFirstView(event)

--- a/corona-app/spec/data-import_spec.lua
+++ b/corona-app/spec/data-import_spec.lua
@@ -2,7 +2,7 @@ require("busted")
 local dataImport = require("data-import")
 
 describe("Testing the data-import function #dataImport", function()
-  local countries = dataImport()
+  local countries = dataImport("data/country.json")
 
   it("should have the right number of countries", function()
     -- There are 113 countries in the data file
@@ -12,7 +12,11 @@ describe("Testing the data-import function #dataImport", function()
       totalItems = totalItems + 1
     end
 
-    assert.are.same(totalItems, 113)
+    -- If all countries had flags it would be 113
+    -- assert.are.same(totalItems, 113)
+
+    -- 93 countries have flags and are included
+    assert.are.same(totalItems, 93)
   end)
 
   describe("Contains values for the country Afghanistan", function()
@@ -27,7 +31,7 @@ describe("Testing the data-import function #dataImport", function()
     end)
 
     it("should countain the country flag file name", function()
-      assert.are.same(afghanistan.flag, 'Afghanistan-01.png')
+      assert.are.same(afghanistan.flag, 'data/flags/Afghanistan-01.png')
     end)
   end)
 end)


### PR DESCRIPTION
The `dataImport` function was directly using this line previously

```lua
local pathForFile = system.pathForFile("data/country.json")
```

The `system` variable is exclusive to corona which failed when running the tests in busted. To fix this the `dataImport` function now accepts a `pathForFile` parameter which should be the path used to read in the JSON file, this allows the unit test to use `data/country.json` and the corona script to use `system.pathForFile("data/country.json")`.